### PR TITLE
Fixed wdocs install issue.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,6 @@ install: ot-recorder ocat
 	mkdir -p $(BUILDROOT)$(INSTALLDIR)/{bin,sbin}
 	mkdir -p $(BUILDROOT)$(STORAGEDEFAULT)
 	mkdir -p $(BUILDROOT)$(DOCROOT)
-	cp -R wdocs $(BUILDROOT)$(DOCROOT)/
+	cp -R wdocs/* $(BUILDROOT)$(DOCROOT)/
 	install --mode 0755 ot-recorder $(BUILDROOT)$(INSTALLDIR)/sbin
 	install --mode 0755 ocat $(BUILDROOT)$(INSTALLDIR)/bin


### PR DESCRIPTION
Would close #19 if merged.  Although it could also be fixed by changing the default `DOCROOT` in `config.mk.in` to omit the final `wdocs/`.