### PR TITLE
Switch to WSS when loading page over HTTPS

### DIFF
--- a/docroot/last/websock.js
+++ b/docroot/last/websock.js
@@ -58,7 +58,7 @@ window.onload = function() {
 	// var url = 'ws://' + location.host + '/ws/last';
 	// console.log(JSON.stringify(location));
 
-	var url = "ws://" + location.host + "/";
+	var url = ("https:" == document.location.protocol ? "wss://" : "ws://") + location.host + "/";
 	var parts = location.pathname.split('/');
 	for (var i = 1; i < parts.length - 2; i++) {
 		url = url + parts[i] + "/";


### PR DESCRIPTION
When recorder is served over HTTPS, we need to switch to secure websockets (WSS) to establish a websockets connection.

Tested with Chrome 45, which currently shows the following warning: 
>Mixed Content: The page at 'https://yourdomain.com/last/index.html' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://yourdomain.com/ws/last'. This request has been blocked; this endpoint must be available over WSS.

This PR switches to WSS when a HTTPS connection is detected, thus eliminating the mixed content warning.