### PR TITLE
allow lowercase time format as provided by http.c

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -230,6 +230,9 @@ static int str_time_to_secs(char *s, time_t *secs)
 			"%Y-%m-%dT%H:%M:%S",
 			"%Y-%m-%dT%H:%M",
 			"%Y-%m-%dT%H",
+			"%Y-%m-%dt%H:%M:%S",
+			"%Y-%m-%dt%H:%M",
+			"%Y-%m-%dt%H",
 			"%Y-%m-%d",
 			"%Y-%m",
 			NULL


### PR DESCRIPTION
Without this patch, only date part will be taken into account from API query parameters from & to. An alternative fix would be to not lowercase them in http.c.