### PR TITLE
Fix for base64 command default column wrapping

### DIFF
--- a/contrib/faces/image2card.sh
+++ b/contrib/faces/image2card.sh
@@ -27,7 +27,7 @@
 # You probably want to do this:
 #
 # image2card.sh filename.jpg "Jane Jolie" > card.json
-# mosquitto_pub -t owntracks/jane/phone/info -f card.json
+# mosquitto_pub -t owntracks/jane/phone/info -f card.json -r
 #
 # Note: the two commands cannot be piplelined (mosquitto_pub -l)
 # because of a bug in mosquitto_pub: https://bugs.eclipse.org/bugs/show_bug.cgi?id=478917
@@ -38,7 +38,7 @@
 imagefile="$1"
 fullname="$2"
 
-imgdata=$(convert "${imagefile}" -resize '40x40!' - | base64)
+imgdata=$(convert "${imagefile}" -resize '40x40!' - | base64 -w 0)
 cat <<EndOfFile
 {"_type":"card","name":"${fullname}","face":"${imgdata}"}
 EndOfFile


### PR DESCRIPTION
base64 defaults to 76 colums (base64 (GNU coreutils) 8.13)
-w, --wrap=COLS
              wrap encoded lines after COLS character (default 76).  Use 0 to disable line wrapping

also added -r flag to the  mosquitto_pub in the comments