### PR TITLE
added base64 version check

### DIFF
--- a/contrib/faces/image2card.sh
+++ b/contrib/faces/image2card.sh
@@ -38,7 +38,11 @@
 imagefile="$1"
 fullname="$2"
 
-imgdata=$(convert "${imagefile}" -resize '40x40!' - | base64 -w 0)
+base64switch=""
+base64check=$(echo "jj" | base64 -w 0 > /dev/null 2>&1)
+[ "$?" -eq "0" ] && base64switch="-w 0"
+imgdata=$(convert "${imagefile}" -resize '40x40!' - | base64 $base64switch)
+
 cat <<EndOfFile
 {"_type":"card","name":"${fullname}","face":"${imgdata}"}
 EndOfFile


### PR DESCRIPTION
We're unable to use $OSTYPE since it's not exposed with minimal /bin/sh, so I came up with a rather ugly way to check if base64 command supports the -w switch by checking the command exit code.

tested on both rapsbian wheezy and os/x mavericks