### PR TITLE
fix for slash html entity &#47; in map_marker tooltip (live map)

### DIFF
--- a/docroot/last/functions.js
+++ b/docroot/last/functions.js
@@ -146,10 +146,10 @@ function map_marker(loc)
 
 	if (loc.addr) {
 		htmldesc = "<b>{{userdev}}</b><br/>{{addr}}<br/><span class='extrainfo'>{{ghash}} <span class='latlon'>({{lat}},{{lon}})</span> {{fulldate}}</span>";
-		shortdesc = "{{userdev}} {{addr}}";
+		shortdesc = "{{{userdev}}} {{addr}}";
 	} else {
 		htmldesc = "<b>{{userdev}}</b><br/>{{lat}}, {{lon}}<br/><span class='extrainfo'>{{ghash}} <span class='latlon'>({{lat}},{{lon}})</span> {{fulldate}}</span>";
-		shortdesc = "{{userdev}} {{lat}},{{lon}}";
+		shortdesc = "{{{userdev}}} {{lat}},{{lon}}";
 	}
 
 	if (loc.face) {


### PR DESCRIPTION
Simple fix using the correct Mustache (triple mustache {{{name}}}) syntax to return unescaped HTML