### PR TITLE
make systemd.service use config-file

### DIFF
--- a/debian/ot-recorder.service
+++ b/debian/ot-recorder.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=simple
 User=owntracks
+EnvironmentFile=/etc/default/ot-recorder
 ExecStart=/usr/sbin/ot-recorder
 
 [Install]


### PR DESCRIPTION
this sources the config-file needed to start the service.
(should this also be applied to the other systemd.service-file?)

We should perhaps add some documentation somewhere that the config-file has to be uncommented to work :-) (at least in v0.6.7-0-deb8.0 that is needed)