### PR TITLE
Update `leaflet.js` CDN URL

### DIFF
--- a/docroot/map/index.html
+++ b/docroot/map/index.html
@@ -36,7 +36,7 @@
           script.src = 'https://maps.googleapis.com/maps/api/js?v=3' +
             '&signed_in=true&key=' + apiKey +'&callback=initialize_googlemaps';
         } else {
-          $("head").append("<link rel='stylesheet' href='https://unpkg.com/leaflet@1.0.2/dist/leaflet.css' type='text/css' />");
+          $("head").append("<link rel='stylesheet' href='https://unpkg.com/leaflet@1.2.0/dist/leaflet.css' type='text/css' />");
           // Dynamic script loading from http://stackoverflow.com/a/8578840
           (function(d, s, id){
             var js, fjs = d.getElementsByTagName(s)[0];
@@ -45,7 +45,7 @@
             js.onload = function(){
               initialize_leaflet();
             };
-            js.src = "https://unpkg.com/leaflet@1.0.2/dist/leaflet.js";
+            js.src = "https://unpkg.com/leaflet@1.2.0/dist/leaflet.js";
             fjs.parentNode.insertBefore(js, fjs);
           }(document, 'script', 'leaflet'));
         }


### PR DESCRIPTION
Ref: owntracks/recorder#206

The URL for `leaflet.js` 1.0.2 is being served as `text/plain`
and also with `nosniff` - this upsets Firefox 54 and consequently
no map is displayed.  Updating the URL to point to the new
1.2.0 version (served as `application/javascript`!) fixes the map.