### PR TITLE
update storage.c to include xmlns on gpx export

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -1039,7 +1039,7 @@ char *gpx_string(JsonNode *location_array)
 	utstring_renew(xml);
 
 	utstring_printf(xml, "%s", "<?xml version='1.0' encoding='UTF-8' standalone='no' ?>\n\
-<gpx version='1.1' creator='OwnTracks-Recorder'>\n\
+<gpx version='1.1' creator='OwnTracks-Recorder' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://www.topografix.com/GPX/1/1'>\n\
  <trk>\n\
   <trkseg>\n");
 


### PR DESCRIPTION
at least one downstream tool (RouteConverter) will not accept .gpx files w/o proper namespace information - suggesting to add xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://www.topografix.com/GPX/1/1'