### PR TITLE
Identify location lines based on _type field

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -795,11 +795,11 @@ static int candidate_line(char *line, void *param)
 	}
 
 	/* Do we have location line? */
-	if ((bp = strstr(line, "Z\t* ")) == NULL) {	/* Not a location line */
+	if ((bp = strstr(line, "_type\":\"location\"")) == NULL) {	/* Not a location line */
 		return (0);
 	}
 
-	if ((bp = strrchr(bp, '\t')) == NULL) {
+	if ((bp = strrchr(line, '\t')) == NULL) {
 		return (0);
 	}
 


### PR DESCRIPTION
This is related to issue #224. In the original file, it seemed that the search string "Z\t* " was not processed as regex by the strstr() function. Hence replacing the '*'-based regex pattern by a string to identify location data lines based on "_type". 

With this, the "bp" pointer had to start search the last '\t' in the data line from the beginning of the line.

I could not see from the strstr() source-code in GCC how it would process regex patterns at all ?