### PR TITLE
Add `acc` field to GeoJSON point feature properties

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -919,7 +919,7 @@ void locations(char *filename, JsonNode *obj, JsonNode *arr, time_t s_lo, time_t
  *
  */
 
-static void append_to_feature_array(JsonNode *features, double lat, double lon, char *tid, char *addr, long tst, long vel)
+static void append_to_feature_array(JsonNode *features, double lat, double lon, char *tid, char *addr, long tst, long vel, long acc)
 {
 	JsonNode *geom, *props, *f = json_mkobject();
 
@@ -937,6 +937,7 @@ static void append_to_feature_array(JsonNode *features, double lat, double lon, 
                   json_append_member(props, "address", json_mkstring(addr));
                   json_append_member(props, "vel", json_mknumber(vel));
                   json_append_member(props, "tst", json_mknumber(tst));
+                  json_append_member(props, "acc", json_mknumber(acc));
 
         json_append_member(f, "geometry", geom);
         json_append_member(f, "properties", props);
@@ -959,12 +960,11 @@ JsonNode *geo_json(JsonNode *location_array)
 	json_foreach(one, location_array) {
 		double lat = 0.0, lon = 0.0;
 		char *addr = "", *tid = "";
-		long tst = 0, vel = 0;
+		long tst = 0, vel = 0, acc = 0;
 
                 if ((j = json_find_member(one, "lat")) != NULL) {
                         lat = j->number_;
                 }
-
                 if ((j = json_find_member(one, "lon")) != NULL) {
                         lon = j->number_;
                 }
@@ -980,8 +980,11 @@ JsonNode *geo_json(JsonNode *location_array)
                 if ((j = json_find_member(one, "vel")) != NULL) {
                         vel = j->number_;
                 }
+                if ((j = json_find_member(one, "acc")) != NULL) {
+                        acc = j->number_;
+                }
 
-		append_to_feature_array(feature_array, lat, lon, tid, addr, tst, vel);
+		append_to_feature_array(feature_array, lat, lon, tid, addr, tst, vel, acc);
 	}
 
 	json_append_member(fcollection, "features", feature_array);


### PR DESCRIPTION
Closes #282 

When acc is not available, it'll default to zero like the `tst` and `vel` properties.