### PR TITLE
Send `Content-Length` header in `json_response`

### DIFF
--- a/http.c
+++ b/http.c
@@ -364,9 +364,15 @@ static int json_response(struct mg_connection *conn, JsonNode *json)
 	mg_send_header(conn, "Access-Control-Allow-Origin", "*");
 
 	if (json == NULL) {
+		mg_send_header(conn, "Content-Length", "2");
 		mg_printf_data(conn, "{}");
 	} else {
 		if ((js = json_stringify(json, JSON_INDENT)) != NULL) {
+			size_t content_length = strlen(js);
+			int length = snprintf(NULL, 0, "%zu", content_length);
+			char buffer[length + 1];
+			snprintf(buffer, length, "%zu", content_length);
+			mg_send_header(conn, "Content-Length", buffer);
 			mg_printf_data(conn, js);
 			free(js);
 		}


### PR DESCRIPTION
This is useful for large responses (imagine years of location data), so the client can compute a progress percentage.

It works, but I'm not sure if this is the best way of doing it, or a good one at all. My C is terrible.