### PR TITLE
Remove accidental eval

### DIFF
--- a/docroot/last/websock.js
+++ b/docroot/last/websock.js
@@ -31,7 +31,7 @@ export function ws_connect(ws_url, callback) {
 
   ws.onclose = function() {
     setColor(maplabel, 'red');
-    setTimeout(ws_connect(ws_url, callback), reconnectTimeout, ws_url, callback);
+    setTimeout(ws_connect, reconnectTimeout, ws_url, callback);
   };
 
   ws.onmessage = function(event) {


### PR DESCRIPTION
This call constitutes an `eval` operation, which is generally bad practice in JS, and results in errors if you run the page with a strict [`Content Security Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).

Calling the function by reference does not invoke `eval` :)