### PR TITLE
google-import: import re

### DIFF
--- a/contrib/google-import/google-import.py
+++ b/contrib/google-import/google-import.py
@@ -8,6 +8,7 @@ import time
 import argparse
 import json
 from paho.mqtt import client, publish
+import re
 
 class ProtocolAction(argparse.Action):
 	def __call__(self, parser, namespace, value, option_string=None):


### PR DESCRIPTION
Script uses `re.compile` on line 17 (now 18), which broke as `import re` was not specified.