### PR TITLE
Make putrec hook also decide whether `last` and websocket update

### DIFF
--- a/doc/HOOKS.md
+++ b/doc/HOOKS.md
@@ -80,7 +80,7 @@ It is 14:10:01 in the year 2015 owntracks/jane/phone lat=48.858339 Avenue Anatol
 An optional function you provide is called `otr_putrec(u, d, s)`. If it exists,
 it is called with the current user in `u`, the device in `d` and the payload
 (which for OwnTracks apps is JSON but for, eg Greenwich devices might not be) in the string `s`. If your function returns a
-non-zero value, the Recorder will *not* write the REC file for this publish.
+non-zero value, the Recorder will *not* write the REC file for this publish, will *not* update the `last` record, and will *not* forward the publish over the websocket (if used).
 
 ## `otr_httpobject`
 


### PR DESCRIPTION
Current hook just governs whether the record is written, but this means that the `last` file and the live websocket would still be updated with data that the user decided to filter. Now we use the hook to skip those steps as well.
Update HOOKS.md to note the functionality change

This is a simple implementation of the change, but I'd also consider changing the hook name internally and refactoring a bit further to avoid putting the lua check everywhere.

Closes #458 