### PR TITLE
Don't check fences when user submits a waypoint

### DIFF
--- a/recorder.c
+++ b/recorder.c
@@ -1372,8 +1372,10 @@ void handle_message(void *userdata, char *topic, char *payload, size_t payloadle
 		}
 	}
 
-	check_fences(ud, UB(username), UB(device), lat, lon, json, topic);
-	check_fences(ud, "_", "_", lat, lon, json, topic);
+    if (_type == T_LOCATION || _type == T_TRANSITION) {
+        check_fences(ud, UB(username), UB(device), lat, lon, json, topic);
+        check_fences(ud, "_", "_", lat, lon, json, topic);
+    }
 
     cleanup:
 	if (geo)	json_delete(geo);


### PR DESCRIPTION
The coordinates of this waypoint may or may not be a user's current location. The code treats them as a fresh location however, and if this fresh location causes a boundary transition, the fence check will fire the lua hook with a transition event.

This extra condition check ensures that the waypoint isn't treated as the user's location.