### PR TITLE
Fix the view lastpos response.

### DIFF
--- a/http.c
+++ b/http.c
@@ -1105,7 +1105,6 @@ static int view(struct mg_connection *conn, const char *viewname)
 			json_append_member(obj, "data", locarray);
 
 			json_delete(view);
-			json_delete(locarray);
 
 			return (json_response(conn, obj));
 			/* NOTREACHED */


### PR DESCRIPTION
The locarray json data is transferred to the response object and if it is deleted here results in an empty object being returned to the user and the default view just shows "Imported data is malformed" instead of a map. This restores the vmap functionality.