### PR TITLE
issue #450: add card data to websocket notifications

### DIFF
--- a/recorder.c
+++ b/recorder.c
@@ -1373,6 +1373,8 @@ void handle_message(void *userdata, char *topic, char *payload, size_t payloadle
 				safewrite(UB(ts), jsonstring);
 				free(jsonstring);
 			}
+
+			append_card_to_object(json, UB(username), UB(device));
 		}
 	}
 


### PR DESCRIPTION
When processing the most recent location update this gets pushed over the websocket to update the live map last position. If a card is present it needs to be added just before this push occurs.