### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The following configuration variables can be used to tweak settings. Defaults ar
 | --------------------- | :---  | :------------ | ---------------
 | `OTR_STORAGEDIR`      |  Y    | compiled in   | Pathname to the storage directory (`-S`)
 | `OTR_HOST`            |  Y    | `localhost`   | MQTT hostname/address to connect to 
-| `OTR_PORT`            |  Y    | `1883`        | MQTT port number to connect to
+| `OTR_PORT`            |  Y    | `1883`        | MQTT port number to connect to. Setting this to 0 disables MQTT
 | `OTR_USER`            |  Y    |               | MQTT username
 | `OTR_PASS`            |  Y    |               | MQTT password
 | `OTR_QOS`             |  Y    | `2`           | MQTT QoS


### PR DESCRIPTION
Updated readme to describe how to disable mqtt in the "configuration variables" table.

I spent an embarrassing amount of time trying to figure out how to disable mqtt. I skimmed right to the config variable table in an effort to figure out how to get set up quicker. I later found written elsewhere in the readme file that setting the mqtt port to 0 disables it. Definitely a patience/not wanting to read issue on my part, but it would be nice to have that information in the table too :)