### PR TITLE
Add support for OpenBSD

### DIFF
--- a/util.c
+++ b/util.c
@@ -33,7 +33,11 @@
 #include <stdarg.h>
 #include <math.h>
 #ifdef WITH_TOURS
+#ifdef __OpenBSD__
+# include <uuid.h>
+#else
 # include <uuid/uuid.h>
+#endif
 #endif
 #include "udata.h"
 
@@ -672,10 +676,26 @@ char *uuid4()
 {
         static char uustr[37];
         uuid_t uu;
+#ifdef __OpenBSD__
+        uint32_t status;
+        char *temp_uustr;
 
+        uuid_create(&uu, &status);
+        if (status != uuid_s_ok) {
+                printf("could not create uuid\n");
+                return (uustr);
+        }
+
+        uuid_to_string(&uu, &temp_uustr, &status);
+        if (status != uuid_s_ok) {
+                printf("could not stringify uuid\n");
+                return (uustr);
+        }
+        strlcpy(uustr, temp_uustr, 37);
+#else
         uuid_generate(uu);
         uuid_unparse_lower(uu, uustr);
-
+#endif
         return (uustr);
 }
 


### PR DESCRIPTION
I'm submitting this this patch for preliminary review; I don't think this is quite ready to be merged yet.

I've kept the comment in `config.mk.in` concise; I'm writing a port downstream so dependencies and other instructions will be encoded there.

The uuid interface that I used in part of the base system, so the best fit for this case. The docs are available at https://man.openbsd.org/uuid_create.3.

The implementation of the `uuid4` function is a bit odd, but it's been done so in order to keep the same API; it always returns a statically allocated uuid which the caller MUST NOT attempt to free.