### PR TITLE
use storage dir from env even when the defaults file is missing

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -171,10 +171,10 @@ void get_defaults(char *filename, struct udata *ud)
 			config_destroy(cf);
 			exit(2);
 		}
-
-		v = c_str(cf, "OTR_STORAGEDIR", STORAGEDEFAULT);
-		strcpy(STORAGEDIR, v);
 	}
+
+	v = c_str(cf, "OTR_STORAGEDIR", STORAGEDEFAULT);
+	strcpy(STORAGEDIR, v);
 
 	if (ud == NULL) {
 		/* being invoked by ocat; return */


### PR DESCRIPTION
When default config file doesn't exist, the storage dir should be still settable via env variables.