### PR TITLE
Look up the timezone when an entry is recorded and store it

### DIFF
--- a/recorder.c
+++ b/recorder.c
@@ -55,7 +55,10 @@
 #endif
 #include "version.h"
 #include <dirent.h>
-
+#ifdef WITH_TZ
+# include "zonedetect.h"
+extern ZoneDetect *zdb;
+#endif
 
 #define SSL_VERIFY_PEER (1)
 #define SSL_VERIFY_NONE (0)
@@ -1055,6 +1058,16 @@ void handle_message(void *userdata, char *topic, char *payload, size_t payloadle
 			t = strdup(j->string_);
 		}
 	}
+
+#ifdef WITH_TZ
+	if ((j = json_find_member(json, "tzname")) == NULL) {
+		char* tz_str = ZDHelperSimpleLookupString(zdb, lat, lon);
+		if (tz_str) {
+			json_append_member(json, "tzname", json_mkstring(tz_str));
+			ZDHelperSimpleLookupStringFree(tz_str);
+		}
+	}
+#endif
 
 	if ((j = json_find_member(json, "_geoprec")) != NULL) {
 		if (j->tag == JSON_STRING) {

--- a/storage.c
+++ b/storage.c
@@ -46,7 +46,7 @@ static struct gcache *gc = NULL;
 
 #ifdef WITH_TZ
 # include "zonedetect.h"
-static ZoneDetect *zdb = NULL;
+ZoneDetect *zdb = NULL;
 #endif
 
 void storage_init(int revgeo)


### PR DESCRIPTION
When requesting many locations that do not have a tzname in the .rec file, lookups can become extremely slow. OwnTracks should look up and record the timezone once when it receives a new entry. This avoids having to perform an expensive lookup against the timezone database in `line_to_location` during retrieval.

This patch uses the same mechanism OwnTracks already employs to determine the timezone at retrieval time, but instead writes the result to the .rec file. OwnTracks already has the fast path implemented to then skip the timezone database lookup during retrieval.