### PR TITLE
Add referrer meta tag to htdocs/map/index.html

### DIFF
--- a/docroot/map/index.html
+++ b/docroot/map/index.html
@@ -5,6 +5,7 @@
     <title>GeoJSON track</title>
     <meta name="viewport" content="width=device-width, height=device-height, user-scalable=no, initial-scale=1.0" />
 
+    <meta name="referrer" content="origin">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="icon" sizes="192x192" href="../static/recorder.png">


### PR DESCRIPTION
Add the referrer meta tag to prevent errors when downloading map tiles.